### PR TITLE
Fix gzip compression within webpack and add compressed file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bundle.js
 coverage
 .gz
 bundle.js.br
+bundle.js.gz

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,7 @@ module.exports = {
   },
   plugins: [
     new CompressionPlugin({
-    filename: '[path].gz[query]',
+    filename: '[path][base].gz[query]',
     algorithm: 'gzip',
     test: /\.js$|\.css$|\.html$/,
     threshold: 10240,


### PR DESCRIPTION
Building a bundle in webpack now produces a properly named gzip file as well as a Brotli and regular bundle.js file.